### PR TITLE
Add `rexagod` to `milestone-maintainers`

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -109,6 +109,7 @@ teams:
     - ramrodo # Release Manager Associate / 1.30 RT Lead Shadow
     - rashansmith # 1.30 Release Notes Lead
     - ritazh # Auth
+    - rexagod # Instrumentation
     - saad-ali # Storage
     - salaxander # Release Manager Associate / 1.29 RT EA
     - salehsedghpour # 1.30 Enhancements Lead


### PR DESCRIPTION
Hello. 👋

I'd like for me to be able to use [certain commands](https://github.com/kubernetes/enhancements/issues/2305#issuecomment-1902271611), as well as edit descriptions for outstanding issues (that come under the SIG) which have inactive author(s) (who've left). I believe adding myself to the `milestone-maintainers` list should address this.